### PR TITLE
Add simple support for aliases to commands

### DIFF
--- a/aaargh.py
+++ b/aaargh.py
@@ -42,12 +42,13 @@ class App(object):
         """
         return self._parser.set_defaults(**kwargs)
 
-    def cmd(self, _func=_NO_FUNC, name=None, *args, **kwargs):
+    def cmd(self, _func=_NO_FUNC, name=None, alias=None, *args, **kwargs):
         """Decorator to create a command line subcommand for a function.
 
         By default, the name of the decorated function is used as the
         name of the subcommand, but this can be overridden by specifying the
-        `name` argument. Additional arguments are passed to the subcommand's
+        `name` argument. Aliases are also possible via the alias argument.
+        Additional arguments are passed to the subcommand's
         :py:class:`ArgumentParser`.
         """
         if _func is not _NO_FUNC:
@@ -65,7 +66,10 @@ class App(object):
             parser_kwargs.setdefault('help', "")  # improves --help output
             subparser = self._subparsers.add_parser(
                     subcommand, *parser_args, **parser_kwargs)
-
+            parser_map = self._subparsers._name_parser_map
+            aliases = [alias] if isinstance(alias, basestring) else (alias or [])
+            for subcommand_alias in aliases:
+                parser_map[subcommand_alias] = parser_map[subcommand]
             # Add global arguments to subcommand as well so that they
             # can be given after the subcommand on the CLI.
             for global_args, global_kwargs in self._global_args:


### PR DESCRIPTION
Great library!
This makes it easier to support shorter versions of commands - I'm doing an implementation of todo.txt that has aliases like list = ls etc; this lets me specify that with a single command-line argument.
