### PR TITLE
add LICENSE.rst to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENSE.rst


### PR DESCRIPTION
Include LICENSE.rst in source distribution. When LICENSE.rst appeared in cd13d3ec61844f7d3f2a2e37025b7358ae13c11d it wasn't included in MANIFEST.in so it wasn't distributed e.g. in aaargh-0.7.tar.gz source distribution on pypi.
